### PR TITLE
A.0.2

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -69,44 +69,19 @@ export async function POST(req: NextRequest) {
     }
 
     // Build the system prompt with document context
-    const systemPrompt = `You are a helpful assistant for students. You have access to the following class materials:
+    const systemPrompt = `You are a friendly, knowledgeable study assistant. You have access to the student's class materials below.
 
-  ${context}
+${context}
 
-  ## Rules
-  - Answer questions ONLY using the provided documents.
-  - Do NOT use jargon unless the user asks for technical detail.
-  - Do NOT assume expert background knowledge.
-  - Keep sentences under 20 words when possible.
-  - Avoid speculation; say "I'm not sure" if uncertain.
-  - Prefer concrete examples over abstract explanations.
-  - Be concise and structured.
-  - If instructions are ambiguous, ask a clarification question.
-
-  ## Required response format
-  Before the final answer, include a short reasoning summary with these headings:
-  - Key facts
-  - Approach
-  - Final answer
-
-  Then return the final answer in this exact XML format:
-
-  <answer>
-  <main_point>...</main_point>
-  <steps>
-  - step 1
-  - step 2
-  </steps>
-  <example>...</example>
-  <conclusion>...</conclusion>
-  </answer>
-
-  ## Source requirement
-  After the XML, include a source block using exact quotes from the documents:
-  > "Exact supporting quote from the document."
-  > — <document filename>
-
-  If the answer is not in the documents, say: "I don't have that information in the provided materials." and still include the reasoning summary, the XML structure with empty fields, and an empty source block.`;
+## How to respond
+- Be conversational, warm, and helpful — like a smart classmate explaining things.
+- Use clean **Markdown** formatting: headings (##), **bold** for key terms, bullet lists, and numbered steps where they help.
+- Keep answers concise but complete. Avoid walls of text.
+- Paraphrase and synthesize — do NOT copy-paste from the documents.
+- Use concrete examples and plain language. Avoid unnecessary jargon.
+- If the answer isn't in the documents, say so honestly.
+- Do NOT include source citations or document references in your response — those are handled separately by the app.
+- Never output XML tags, raw document text, or reasoning scaffolding. Just give a clean, readable answer.`;
 
     console.log(`[Chat] Processing query for class ${classId}: "${message}"`);
     console.log(`[Chat] Using context from ${documents.length} document(s)`);
@@ -122,10 +97,14 @@ export async function POST(req: NextRequest) {
 
     console.log(`[Chat] Generated response for class ${classId}`);
 
+    // Collect source filenames for attribution
+    const sources = documents.map((doc) => doc.filename);
+
     return NextResponse.json({
       success: true,
       response: result.text,
       documentsUsed: documents.length,
+      sources,
     });
   } catch (error) {
     console.error('[Chat] Error:', error);

--- a/app/components/HomeChat.tsx
+++ b/app/components/HomeChat.tsx
@@ -17,6 +17,7 @@ type ClassOption = {
 type Message = {
   role: "user" | "assistant";
   content: string;
+  sources?: string[];
 };
 
 function getInitials(title: string) {
@@ -65,7 +66,7 @@ export default function HomeChat({ classes }: { classes: ClassOption[] }) {
       const data = await response.json();
       setMessages((prev) => [
         ...prev,
-        { role: "assistant", content: data.response },
+        { role: "assistant", content: data.response, sources: data.sources ?? [] },
       ]);
     } catch (error) {
       console.error("Chat error:", error);
@@ -100,17 +101,34 @@ export default function HomeChat({ classes }: { classes: ClassOption[] }) {
                 }`}
               >
                 <div
-                  className={`max-w-lg rounded-2xl px-4 py-3 ${
+                  className={`rounded-2xl px-4 py-3 ${
                     msg.role === "user"
-                      ? "bg-cyan-300 text-black"
-                      : "bg-white/5 text-zinc-100 ring-1 ring-white/10"
+                      ? "max-w-lg bg-cyan-300 text-black"
+                      : "max-w-2xl bg-white/5 text-zinc-100 ring-1 ring-white/10"
                   }`}
                 >
                   {msg.role === "assistant" ? (
-                    <div className="prose prose-invert max-w-none text-sm">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {msg.content}
-                      </ReactMarkdown>
+                    <div>
+                      <div className="prose prose-invert prose-sm max-w-none prose-headings:text-zinc-50 prose-headings:font-semibold prose-headings:mt-4 prose-headings:mb-2 prose-p:leading-relaxed prose-li:leading-relaxed prose-strong:text-cyan-200 prose-code:text-cyan-300 prose-code:bg-white/10 prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-a:text-cyan-300">
+                        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                          {msg.content}
+                        </ReactMarkdown>
+                      </div>
+                      {msg.sources && msg.sources.length > 0 && (
+                        <div className="mt-3 flex flex-wrap gap-2 border-t border-white/10 pt-3">
+                          {msg.sources.map((src, i) => (
+                            <span
+                              key={i}
+                              className="inline-flex items-center gap-1.5 rounded-full bg-white/5 px-3 py-1 text-[11px] font-medium text-zinc-400 ring-1 ring-white/10 select-none"
+                            >
+                              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="currentColor" className="h-3 w-3 text-zinc-500">
+                                <path fillRule="evenodd" d="M4 2a1.5 1.5 0 0 0-1.5 1.5v9A1.5 1.5 0 0 0 4 14h8a1.5 1.5 0 0 0 1.5-1.5V6.621a1.5 1.5 0 0 0-.44-1.06L9.94 2.439A1.5 1.5 0 0 0 8.878 2H4Zm4 3.5a.75.75 0 0 1 .75.75v2.69l.72-.72a.75.75 0 1 1 1.06 1.06l-2 2a.75.75 0 0 1-1.06 0l-2-2a.75.75 0 0 1 1.06-1.06l.72.72V6.25A.75.75 0 0 1 8 5.5Z" clipRule="evenodd" />
+                              </svg>
+                              {src}
+                            </span>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   ) : (
                     msg.content


### PR DESCRIPTION
This pull request enhances the chat assistant experience by making responses more conversational and user-friendly, updating the language model, and adding source attribution for document context. The changes span both backend and frontend, improving how document sources are tracked and displayed to users.

**Chat assistant prompt and AI model improvements:**

* Updated the system prompt in `app/api/chat/route.ts` to instruct the assistant to be conversational, synthesize information, and avoid copying text or including source citations in responses. The prompt now emphasizes clarity, warmth, and helpfulness.
* Changed the AI model used for generating responses from `llama-3.3-70b-versatile` to `openai/gpt-oss-120b` for potentially improved answer quality.

**Source attribution and UI enhancements:**

* Backend now collects source filenames from documents and returns them in the API response, enabling attribution in the UI.
* The `Message` type in `app/components/HomeChat.tsx` was extended to include an optional `sources` field, and assistant messages now include source filenames. [[1]](diffhunk://#diff-73b999cc223a912c2c3a697cfeaec29f3a8d1351ef2d94f6f1719389c2dec040R20) [[2]](diffhunk://#diff-73b999cc223a912c2c3a697cfeaec29f3a8d1351ef2d94f6f1719389c2dec040L68-R69)
* The chat UI displays source filenames as labeled tags beneath assistant responses, improving transparency about which documents were used. Also, styling for responses was updated for better readability and visual distinction.