### PR TITLE
A.0.8

### DIFF
--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -2,6 +2,7 @@ import { auth, signIn } from "@/auth";
 import TimezoneInput from "@/app/components/TimezoneInput";
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { AuthError } from "next-auth";
 
 type SignInPageProps = {
   searchParams?: Promise<{
@@ -66,12 +67,21 @@ export default async function SignInPage({ searchParams }: SignInPageProps) {
                   .toLowerCase();
                 const password = String(formData.get("password") ?? "");
                 const timezone = String(formData.get("timezone") ?? "").trim();
-                await signIn("credentials", {
-                  email,
-                  password,
-                  redirectTo: callbackUrl,
-                  timezone,
-                });
+                try {
+                  await signIn("credentials", {
+                    email,
+                    password,
+                    redirectTo: callbackUrl,
+                    timezone,
+                  });
+                } catch (error) {
+                  if (error instanceof AuthError && error.type === "CredentialsSignin") {
+                    redirect(
+                      `/signin?error=CredentialsSignin&callbackUrl=${encodeURIComponent(callbackUrl)}`
+                    );
+                  }
+                  throw error;
+                }
               }}
               className="flex flex-col gap-3"
             >

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -5,6 +5,7 @@ import TimezoneInput from "@/app/components/TimezoneInput";
 import { prisma } from "@/lib/prisma";
 import { hashPassword } from "@/lib/password";
 import { redirect } from "next/navigation";
+import { AuthError } from "next-auth";
 
 type SignUpPageProps = {
   searchParams?: Promise<{
@@ -95,12 +96,21 @@ export default async function SignUpPage({ searchParams }: SignUpPageProps) {
                 },
               });
 
-              await signIn("credentials", {
-                email,
-                password,
-                redirectTo: callbackUrl,
-                timezone: timeZone,
-              });
+              try {
+                await signIn("credentials", {
+                  email,
+                  password,
+                  redirectTo: callbackUrl,
+                  timezone: timeZone,
+                });
+              } catch (error) {
+                if (error instanceof AuthError && error.type === "CredentialsSignin") {
+                  redirect(
+                    `/signin?error=CredentialsSignin&callbackUrl=${encodeURIComponent(callbackUrl)}`
+                  );
+                }
+                throw error;
+              }
             }}
             className="mt-6 flex flex-col gap-3"
           >

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -12,7 +12,26 @@ if (!connectionString) {
   throw new Error('DATABASE_URL is not set. Add it to .env.local (or .env).')
 }
 
-const adapter = new PrismaPg({ connectionString })
+function normalizeConnectionString(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl)
+    const sslMode = url.searchParams.get('sslmode')?.toLowerCase()
+    const useLibpqCompat = url.searchParams.get('uselibpqcompat')?.toLowerCase() === 'true'
+    const aliasedModes = new Set(['prefer', 'require', 'verify-ca'])
+
+    if (sslMode && aliasedModes.has(sslMode) && !useLibpqCompat) {
+      url.searchParams.set('sslmode', 'verify-full')
+    }
+
+    return url.toString()
+  } catch {
+    return rawUrl
+  }
+}
+
+const normalizedConnectionString = normalizeConnectionString(connectionString)
+
+const adapter = new PrismaPg({ connectionString: normalizedConnectionString })
 
 export const prisma = globalThis.__prisma ?? new PrismaClient({
   adapter,


### PR DESCRIPTION
This pull request introduces improved error handling for authentication flows and enhances database connection string normalization. The main changes are grouped into authentication error handling improvements in the sign-in and sign-up pages, and connection string normalization in the Prisma database adapter setup.

Authentication error handling:

* Added handling for `AuthError` during sign-in and sign-up; if the error is of type `CredentialsSignin`, users are redirected to the sign-in page with an error message and callback URL. (`app/signin/page.tsx`, `app/signup/page.tsx`) [[1]](diffhunk://#diff-d63b5c8de25089f5ee5d3e1da292a936994f07f8c0fe05e35b01f89ea1847aeaR5) [[2]](diffhunk://#diff-d63b5c8de25089f5ee5d3e1da292a936994f07f8c0fe05e35b01f89ea1847aeaR70-R84) [[3]](diffhunk://#diff-58364f07e0d228753c21309635f95ba5e3a4bfb3499b77e4607a296381ebee8dR8) [[4]](diffhunk://#diff-58364f07e0d228753c21309635f95ba5e3a4bfb3499b77e4607a296381ebee8dR99-R113)

Database connection string normalization:

* Introduced `normalizeConnectionString` function in `lib/prisma.ts` to adjust the `sslmode` parameter for certain values unless `uselibpqcompat` is set, ensuring compatibility and security for database connections. The normalized connection string is now used when initializing the Prisma adapter.