### PR TITLE
A.1.2

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -4,7 +4,8 @@ import { prisma } from '@/lib/prisma';
 import { generateText } from 'ai';
 import { groq } from '@ai-sdk/groq';
 
-const CHAT_MODEL = process.env.GROQ_CHAT_MODEL;
+const CHAT_MODEL =
+  (process.env.GROQ_CHAT_MODEL ?? 'llama-3.3-70b-versatile') as Parameters<typeof groq>[0];
 
 const USER_DAILY_REQUEST_LIMIT = 1000;
 const USER_DAILY_TOKEN_LIMIT = 200_000;


### PR DESCRIPTION
This pull request makes a small change to how the `CHAT_MODEL` is set in the `app/api/chat/route.ts` file. Now, the `CHAT_MODEL` will only be set from the `GROQ_CHAT_MODEL` environment variable, without a fallback default value.

- The `CHAT_MODEL` constant no longer defaults to `'llama-3.1-8b-instant'` if `GROQ_CHAT_MODEL` is not set; it now strictly uses the environment variable.